### PR TITLE
chore: add bionic professions as no hope's mod req

### DIFF
--- a/data/mods/No_Hope/modinfo.json
+++ b/data/mods/No_Hope/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "Night_Pryanik" ],
     "description": "- Significantly reduced amount of places with guaranteed loot spawns.\n- Loot spawn in buildings is drastically reduced, especially for food, tools, guns etc.\n- Most buildings are destroyed, vandalized, or looted.\n- Most cars are destroyed or at least damaged.  Intact cars are nearly impossible to find.\n- Fuel is much harder to find, almost all cars have no fuel in tanks.\n- Marauders, looters, and bandits everywhere.\n\nSee extended description in README.md.\n\nTo get the mod author's intended playing experience, consider:\n- Enabling wandering hordes.\n- Setting item spawn scaling factor to 0.5 or lower.\n- Setting spawn rate scaling factor to 1.5 or higher.",
     "category": "content",
-    "dependencies": [ "dda" ],
+    "dependencies": [ "dda", "package_bionic_professions" ],
     "version": "3.4"
   },
   {


### PR DESCRIPTION


#### Summary
Mods "[No Hope] add Bionic Professions as the mod's requirement"

#### Purpose of change
The mod restores CBM loots, many of which are part of the Bionic Professions mod, leading to some weird stuffs.

#### Describe the solution
Add the mod as the requirement

#### Describe alternatives you've considered
NONE

#### Testing
It loaded successfully

#### Additional context
I should also restore CBM dissection from bio-ops (idk bout shockers/zappers though)
